### PR TITLE
Beginning of "tinystr" optimization

### DIFF
--- a/src/locale/mod.rs
+++ b/src/locale/mod.rs
@@ -5,6 +5,8 @@ mod options;
 mod parser;
 mod tinystr;
 
+use self::tinystr::{TinyStr4, TinyStr8};
+
 /// A Locale object.
 ///
 /// Locale object stores information encoded in a language tag and provides
@@ -77,7 +79,7 @@ mod tinystr;
 /// ```
 #[derive(Debug, Default, PartialEq, Clone)]
 pub struct Locale {
-    language: Option<String>,
+    language: Option<TinyStr8>,
     extlangs: Option<Vec<String>>,
     script: Option<String>,
     region: Option<String>,

--- a/src/locale/mod.rs
+++ b/src/locale/mod.rs
@@ -79,10 +79,10 @@ use self::tinystr::{TinyStr4, TinyStr8};
 /// ```
 #[derive(Debug, Default, PartialEq, Clone)]
 pub struct Locale {
-    language: Option<TinyStr8>,
+    language: Option<TinyStr4>,
     extlangs: Option<Vec<String>>,
-    script: Option<String>,
-    region: Option<String>,
+    script: Option<TinyStr4>,
+    region: Option<TinyStr4>,
     variants: Option<Vec<String>>,
     extensions: Option<BTreeMap<String, BTreeMap<String, String>>>,
     privateuse: Vec<String>,

--- a/src/locale/mod.rs
+++ b/src/locale/mod.rs
@@ -3,6 +3,7 @@ use std::fmt;
 
 mod options;
 mod parser;
+mod tinystr;
 
 /// A Locale object.
 ///

--- a/src/locale/options.rs
+++ b/src/locale/options.rs
@@ -1,4 +1,4 @@
-use super::{Locale, TinyStr8};
+use super::{Locale, TinyStr4};
 use std::collections::BTreeMap;
 
 pub fn option_name_for_key(key: &str) -> &'static str {
@@ -20,9 +20,11 @@ pub fn option_key_for_name(key: &str) -> &'static str {
 pub fn apply_options(loc: &mut Locale, opts: BTreeMap<&str, &str>) {
     for (key, value) in opts {
         match key {
-            "language" => loc.language = TinyStr8::new(value).ok(),
-            "script" => loc.script = Some(value.to_owned()),
-            "region" => loc.region = Some(value.to_owned()),
+            // TODO: should we do something other than store None on strings
+            // that fail representation?
+            "language" => loc.language = TinyStr4::new(value).ok(),
+            "script" => loc.script = TinyStr4::new(value).ok(),
+            "region" => loc.region = TinyStr4::new(value).ok(),
 
             _ => if let Some(ref mut exts) = loc.extensions {
                 let uext = exts

--- a/src/locale/options.rs
+++ b/src/locale/options.rs
@@ -1,4 +1,4 @@
-use super::Locale;
+use super::{Locale, TinyStr8};
 use std::collections::BTreeMap;
 
 pub fn option_name_for_key(key: &str) -> &'static str {
@@ -20,7 +20,7 @@ pub fn option_key_for_name(key: &str) -> &'static str {
 pub fn apply_options(loc: &mut Locale, opts: BTreeMap<&str, &str>) {
     for (key, value) in opts {
         match key {
-            "language" => loc.language = Some(value.to_owned()),
+            "language" => loc.language = TinyStr8::new(value).ok(),
             "script" => loc.script = Some(value.to_owned()),
             "region" => loc.region = Some(value.to_owned()),
 

--- a/src/locale/parser.rs
+++ b/src/locale/parser.rs
@@ -1,4 +1,5 @@
 use super::options;
+use super::TinyStr8;
 use super::Locale;
 use std::collections::BTreeMap;
 use std::error::Error as ErrorTrait;
@@ -61,12 +62,13 @@ pub fn ext_key_for_name(key: &str) -> &str {
     }
 }
 
-pub fn parse_language_subtag(t: &str) -> Result<String> {
-    if t.len() < 2 || t.len() > 3 || t.chars().any(|c| !c.is_ascii_alphabetic()) {
+pub fn parse_language_subtag(t: &str) -> Result<TinyStr8> {
+    let s = TinyStr8::new(t).map_err(|_| Error::InvalidLanguage)?;
+    if t.len() < 2 || t.len() > 3 || !s.is_all_ascii_alpha() {
         return Err(Error::InvalidLanguage);
     }
 
-    Ok(t.to_ascii_lowercase())
+    Ok(s.to_ascii_lowercase())
 }
 
 pub fn parse_script_subtag(t: &str) -> Result<String> {


### PR DESCRIPTION
This patch implements a "tiny string" datatype, very efficient but limited to bounded lengths, and starts with the integration into the Locale datatype. As of this PR, it's just the language subtag, but I wanted to upload it to get feedback before proceeding further.

Progress towards #7