### PR TITLE
Replace HashMap with HashSet

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,12 +19,12 @@ coveralls = { repository = "projectfluent/fluent-locale-rs", branch = "master", 
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-unic-langid = "0.5"
+unic-langid = { path = "../../unic-locale/unic-langid" }
 
 [dev-dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-unic-locale = { version = "0.5", features = ["macros"] }
+unic-locale = { path = "../../unic-locale/unic-locale", features = ["macros"] }
 criterion = "0.3"
 
 [[bench]]

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -32,7 +32,9 @@ struct AcceptedLanguagesTestSet {
     output: Vec<String>,
 }
 
-fn read_negotiate_testsets<P: AsRef<Path>>(path: P) -> Result<Vec<NegotiateTestSet>, Box<dyn Error>> {
+fn read_negotiate_testsets<P: AsRef<Path>>(
+    path: P,
+) -> Result<Vec<NegotiateTestSet>, Box<dyn Error>> {
     let file = File::open(path)?;
     let sets = serde_json::from_reader(file)?;
     Ok(sets)


### PR DESCRIPTION
This is an alternative approach to https://github.com/projectfluent/fluent-locale-rs/pull/12/ that I got from https://www.reddit.com/r/rust/comments/d1ys9b/hashmaplike_data_structure_where_the_keys_are/ezrcmof/ .

@cmyr - what do you think?

It would require several derives to be added to `LanguageIdentifier` and `Locale`, but nothing outrageous.