### PR TITLE
chore: Release 0.14.1, 'safe harbor'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
   - …
 
+## fluent-langneg 0.14.1 (March 16, 2024)
+
+ - This is a 'safe harbor' release prior to bringing on non-Mozilla community maintainers.
+ - Minor optimizations for speed
+
 ## fluent-langneg 0.14.0 (December 13, 2023)
 
  - Move from using `unic-langid` to `icu-locid`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,8 +3,10 @@ name = "fluent-langneg"
 description = """
 A library for language and locale negotiation.
 """
-version = "0.14.0"
-authors = ["Zibi Braniecki <gandalf@mozilla.com>"]
+version = "0.14.1"
+authors = [
+	"Zibi Braniecki <zibi@unicode.org>"
+]
 homepage = "http://projectfluent.org/"
 license = "Apache-2.0"
 repository = "https://github.com/projectfluent/fluent-langneg-rs"


### PR DESCRIPTION
This release serves as a marker in the transition from the Project Fluent related crates being a wholly Mozilla managed project to bringing on non-Mozilla community maintainers. The safe harbor release series publishes the current Git HEAD of all crates as a convenience to downstream consumers that either audit the code and contributors, don't want to adopt potential changes for whatever reason, or just want an easy reference point against which to compare future releases.

----

Related issues:

* Background to bringing on non-Mozilla maintainers:
  https://github.com/projectfluent/fluent/issues/358

* Discussion of a safe-harbor release series:
  https://github.com/projectfluent/fluent-rs/issues/347

* Matching PR for fluent-rs workspace crates:
  https://github.com/projectfluent/fluent-rs/pull/349
