### PR TITLE
Bump criterion to 0.5 to avoid dependency on atty

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ icu_locid_transform = { version = "1.4", optional = true }
 [dev-dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-criterion = "0.3"
+criterion = "0.5"
 
 [[bench]]
 name = "negotiate"


### PR DESCRIPTION
Criterion before 0.5 depended on atty which is affected by [RUSTSEC-2021-0145](https://rustsec.org/advisories/RUSTSEC-2021-0145)